### PR TITLE
Add global installation mode with per-project initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,62 @@
 
 ## Install (30 seconds)
 
+### Option A: Drop-in (per-project)
+
 1. Copy just the **`marge_simpson/`** folder into your repo root
 2. Use a prompt template below
 
 > **💡 Renamed the folder?** Replace `marge_simpson` with your folder name in prompts.
+
+### Option B: Global Install (multi-project)
+
+For users working across multiple repos who want:
+- **Clean repos** — `marge_simpson/` is gitignored, not committed
+- **Shared resources** — experts, workflows, and knowledge shared globally
+- **Per-project tracking** — MS-IDs and logs isolated per project
+
+**Install globally:**
+```bash
+# macOS/Linux
+./install-global.sh
+
+# Windows
+.\install-global.ps1
+```
+
+**Initialize in any project:**
+```bash
+# macOS/Linux
+cd your-project
+marge-init
+
+# Windows
+cd your-project
+marge-init
+```
+
+This creates `marge_simpson/` with:
+- **Symlinks** to `~/.marge/shared/` (AGENTS.md, experts, workflows, scripts)
+- **Local copies** of tracking files (assessment.md, tasklist.md, verify.config.json)
+- Auto-adds `marge_simpson/` to `.gitignore`
+
+**Structure:**
+```
+~/.marge/
+├── shared/           # Symlinked to all projects
+│   ├── AGENTS.md
+│   ├── experts/      # Add custom experts here (shared across projects)
+│   ├── workflows/
+│   ├── scripts/
+│   └── knowledge/
+├── templates/        # Copied per-project
+│   ├── assessment.md
+│   ├── tasklist.md
+│   └── verify.config.json
+└── marge-init        # Project initialization script
+```
+
+> **💡 Custom experts:** Add domain-specific expert files to `~/.marge/shared/experts/` and they'll be available in all your projects.
 
 ---
 

--- a/install-global.ps1
+++ b/install-global.ps1
@@ -1,0 +1,143 @@
+<#
+.SYNOPSIS
+    Installs marge globally with shared resources and per-project initialization.
+
+.DESCRIPTION
+    Creates a global marge installation at ~/.marge (or custom directory) with:
+    - shared/: Resources symlinked to all projects
+    - templates/: Per-project files copied during init
+    - marge-init.ps1: Script to initialize projects
+
+.PARAMETER InstallDir
+    Installation directory. Default: $env:USERPROFILE\.marge
+
+.PARAMETER Force
+    Overwrite existing installation.
+
+.EXAMPLE
+    .\install-global.ps1
+    .\install-global.ps1 -Force
+    .\install-global.ps1 -InstallDir "D:\tools\marge"
+#>
+
+param(
+    [string]$InstallDir = "$env:USERPROFILE\.marge",
+    [switch]$Force
+)
+
+$ErrorActionPreference = "Stop"
+
+$SrcDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$Src = Join-Path $SrcDir "marge_simpson"
+
+if (-not (Test-Path $Src)) {
+    Write-Error "marge_simpson/ folder not found in $SrcDir"
+    exit 1
+}
+
+if (Test-Path $InstallDir) {
+    if (-not $Force) {
+        Write-Error "$InstallDir already exists. Use -Force to overwrite."
+        exit 1
+    }
+    Write-Host "Removing existing installation..."
+    Remove-Item -Recurse -Force $InstallDir
+}
+
+Write-Host "Installing marge globally to $InstallDir..."
+
+# Create directory structure
+New-Item -ItemType Directory -Force -Path "$InstallDir\shared" | Out-Null
+New-Item -ItemType Directory -Force -Path "$InstallDir\templates" | Out-Null
+
+# Copy shared resources
+$SharedItems = @(
+    "AGENTS.md",
+    "assets",
+    "experts",
+    "knowledge",
+    "model_pricing.json",
+    "prompt_examples",
+    "README.md",
+    "scripts",
+    "VERSION",
+    "workflows"
+)
+
+foreach ($item in $SharedItems) {
+    $srcPath = Join-Path $Src $item
+    if (Test-Path $srcPath) {
+        Copy-Item -Recurse -Force $srcPath "$InstallDir\shared\"
+    }
+}
+
+# Copy per-project templates
+$TemplateItems = @(
+    "assessment.md",
+    "instructions_log.md",
+    "tasklist.md",
+    "verify.config.json"
+)
+
+foreach ($item in $TemplateItems) {
+    $srcPath = Join-Path $Src $item
+    if (Test-Path $srcPath) {
+        Copy-Item -Force $srcPath "$InstallDir\templates\"
+    }
+}
+
+# Install marge-init script
+Copy-Item -Force (Join-Path $SrcDir "marge-init.ps1") "$InstallDir\marge-init.ps1"
+
+# Validate installation
+Write-Host "Validating installation..."
+$Required = @(
+    "$InstallDir\shared\AGENTS.md",
+    "$InstallDir\shared\scripts\verify.ps1",
+    "$InstallDir\shared\workflows",
+    "$InstallDir\shared\experts",
+    "$InstallDir\templates\assessment.md",
+    "$InstallDir\templates\tasklist.md",
+    "$InstallDir\marge-init.ps1"
+)
+
+$Missing = @()
+foreach ($file in $Required) {
+    if (-not (Test-Path $file)) {
+        $Missing += $file
+    }
+}
+
+if ($Missing.Count -gt 0) {
+    Write-Warning "Installation may be incomplete. Missing:"
+    foreach ($f in $Missing) {
+        Write-Warning "  - $f"
+    }
+}
+
+Write-Host ""
+Write-Host "marge installed globally to $InstallDir" -ForegroundColor Green
+Write-Host ""
+Write-Host "Structure:"
+Write-Host "  $InstallDir\"
+Write-Host "  ├── shared\        # Shared resources (symlinked to projects)"
+Write-Host "  │   ├── AGENTS.md"
+Write-Host "  │   ├── experts\"
+Write-Host "  │   ├── workflows\"
+Write-Host "  │   ├── scripts\"
+Write-Host "  │   └── knowledge\"
+Write-Host "  ├── templates\     # Per-project templates"
+Write-Host "  │   ├── assessment.md"
+Write-Host "  │   ├── tasklist.md"
+Write-Host "  │   └── verify.config.json"
+Write-Host "  └── marge-init.ps1 # Project initialization script"
+Write-Host ""
+Write-Host "To use marge-init from anywhere, add to your PowerShell profile:"
+Write-Host "  Add-Content `$PROFILE 'function marge-init { & `"$InstallDir\marge-init.ps1`" @args }'"
+Write-Host ""
+Write-Host "Or add $InstallDir to your PATH."
+Write-Host ""
+Write-Host "Usage:"
+Write-Host "  cd your-project"
+Write-Host "  marge-init          # Initialize marge_simpson/ with symlinks"
+Write-Host "  marge-init -Force   # Reinitialize (overwrites existing)"

--- a/install-global.sh
+++ b/install-global.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# install-global.sh
+# Installs marge globally with shared resources and per-project initialization.
+#
+# Usage: ./install-global.sh [OPTIONS]
+#
+# Options:
+#   -d, --dir DIR     Install directory (default: ~/.marge)
+#   -f, --force       Overwrite existing installation
+#   -h, --help        Show this help message
+#
+# After installation, use 'marge-init' in any project directory to set up
+# marge_simpson/ with symlinks to shared resources and local tracking files.
+
+INSTALL_DIR="${HOME}/.marge"
+FORCE=0
+
+print_usage() {
+    sed -n '3,12p' "$0" | sed 's/^# //' | sed 's/^#//'
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -d|--dir)
+            INSTALL_DIR="$2"
+            shift 2
+            ;;
+        -f|--force)
+            FORCE=1
+            shift
+            ;;
+        -h|--help)
+            print_usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            print_usage
+            exit 1
+            ;;
+    esac
+done
+
+SRC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SRC="$SRC_DIR/marge_simpson"
+
+if [[ ! -d "$SRC" ]]; then
+    echo "Error: marge_simpson/ folder not found in $SRC_DIR" >&2
+    exit 1
+fi
+
+if [[ -d "$INSTALL_DIR" ]]; then
+    if [[ "$FORCE" -ne 1 ]]; then
+        echo "Error: $INSTALL_DIR already exists. Use --force to overwrite." >&2
+        exit 1
+    fi
+    echo "Removing existing installation..."
+    rm -rf "$INSTALL_DIR"
+fi
+
+echo "Installing marge globally to $INSTALL_DIR..."
+
+# Create directory structure
+mkdir -p "$INSTALL_DIR/shared" "$INSTALL_DIR/templates"
+
+# Copy shared resources (symlinked to projects)
+SHARED_FILES=(
+    "AGENTS.md"
+    "assets"
+    "experts"
+    "knowledge"
+    "model_pricing.json"
+    "prompt_examples"
+    "README.md"
+    "scripts"
+    "VERSION"
+    "workflows"
+)
+
+for item in "${SHARED_FILES[@]}"; do
+    if [[ -e "$SRC/$item" ]]; then
+        cp -R "$SRC/$item" "$INSTALL_DIR/shared/"
+    fi
+done
+
+# Copy per-project templates
+TEMPLATE_FILES=(
+    "assessment.md"
+    "instructions_log.md"
+    "tasklist.md"
+    "verify.config.json"
+)
+
+for item in "${TEMPLATE_FILES[@]}"; do
+    if [[ -e "$SRC/$item" ]]; then
+        cp "$SRC/$item" "$INSTALL_DIR/templates/"
+    fi
+done
+
+# Install marge-init script
+cp "$SRC_DIR/marge-init" "$INSTALL_DIR/marge-init"
+chmod +x "$INSTALL_DIR/marge-init"
+
+# Create convenience symlink in ~/.local/bin if it exists or can be created
+LOCAL_BIN="${HOME}/.local/bin"
+if [[ -d "$LOCAL_BIN" ]] || mkdir -p "$LOCAL_BIN" 2>/dev/null; then
+    ln -sf "$INSTALL_DIR/marge-init" "$LOCAL_BIN/marge-init"
+    ADDED_TO_PATH=1
+else
+    ADDED_TO_PATH=0
+fi
+
+# Validate installation
+echo "Validating installation..."
+REQUIRED=(
+    "$INSTALL_DIR/shared/AGENTS.md"
+    "$INSTALL_DIR/shared/scripts/verify.sh"
+    "$INSTALL_DIR/shared/workflows"
+    "$INSTALL_DIR/shared/experts"
+    "$INSTALL_DIR/templates/assessment.md"
+    "$INSTALL_DIR/templates/tasklist.md"
+    "$INSTALL_DIR/marge-init"
+)
+
+MISSING=()
+for file in "${REQUIRED[@]}"; do
+    if [[ ! -e "$file" ]]; then
+        MISSING+=("$file")
+    fi
+done
+
+if [[ ${#MISSING[@]} -gt 0 ]]; then
+    echo "Warning: Installation may be incomplete. Missing:" >&2
+    for f in "${MISSING[@]}"; do
+        echo "  - $f" >&2
+    done
+fi
+
+echo ""
+echo "✓ Marge installed globally to $INSTALL_DIR"
+echo ""
+echo "Structure:"
+echo "  $INSTALL_DIR/"
+echo "  ├── shared/        # Shared resources (symlinked to projects)"
+echo "  │   ├── AGENTS.md"
+echo "  │   ├── experts/"
+echo "  │   ├── workflows/"
+echo "  │   ├── scripts/"
+echo "  │   └── knowledge/"
+echo "  ├── templates/     # Per-project templates"
+echo "  │   ├── assessment.md"
+echo "  │   ├── tasklist.md"
+echo "  │   └── verify.config.json"
+echo "  └── marge-init     # Project initialization script"
+echo ""
+
+if [[ "$ADDED_TO_PATH" -eq 1 ]]; then
+    echo "marge-init has been added to $LOCAL_BIN"
+    if [[ ":$PATH:" != *":$LOCAL_BIN:"* ]]; then
+        echo ""
+        echo "Add to your PATH (if not already):"
+        echo "  echo 'export PATH=\"\$HOME/.local/bin:\$PATH\"' >> ~/.bashrc"
+        echo "  source ~/.bashrc"
+    fi
+else
+    echo "To use marge-init from anywhere, add to your PATH:"
+    echo "  echo 'export PATH=\"$INSTALL_DIR:\$PATH\"' >> ~/.bashrc"
+    echo "  source ~/.bashrc"
+fi
+
+echo ""
+echo "Usage:"
+echo "  cd your-project"
+echo "  marge-init          # Initialize marge_simpson/ with symlinks"
+echo "  marge-init --force  # Reinitialize (overwrites existing)"

--- a/marge-init
+++ b/marge-init
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# marge-init
+# Initialize marge_simpson/ in the current project directory.
+#
+# Creates a hybrid setup with:
+#   - Symlinks to global shared resources (AGENTS.md, experts, workflows, etc.)
+#   - Local per-project files (assessment.md, tasklist.md, verify_logs/)
+#
+# Usage: marge-init [OPTIONS]
+#
+# Options:
+#   -f, --force       Overwrite existing marge_simpson/ folder
+#   -n, --no-gitignore  Don't add marge_simpson/ to .gitignore
+#   -h, --help        Show this help message
+
+MARGE_HOME="${MARGE_HOME:-$HOME/.marge}"
+TARGET_DIR="./marge_simpson"
+FORCE=0
+UPDATE_GITIGNORE=1
+
+print_usage() {
+    sed -n '3,14p' "$0" | sed 's/^# //' | sed 's/^#//'
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -f|--force)
+            FORCE=1
+            shift
+            ;;
+        -n|--no-gitignore)
+            UPDATE_GITIGNORE=0
+            shift
+            ;;
+        -h|--help)
+            print_usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            print_usage
+            exit 1
+            ;;
+    esac
+done
+
+# Validate global installation
+if [[ ! -d "$MARGE_HOME/shared" ]]; then
+    echo "Error: Global marge installation not found at $MARGE_HOME" >&2
+    echo "" >&2
+    echo "Install marge globally first:" >&2
+    echo "  ./install-global.sh" >&2
+    echo "" >&2
+    echo "Or set MARGE_HOME to your installation directory:" >&2
+    echo "  export MARGE_HOME=/path/to/marge" >&2
+    exit 1
+fi
+
+if [[ -e "$TARGET_DIR" ]]; then
+    if [[ "$FORCE" -ne 1 ]]; then
+        echo "Error: $TARGET_DIR already exists." >&2
+        echo "Use --force to overwrite, or remove it manually." >&2
+        exit 1
+    fi
+    echo "Removing existing $TARGET_DIR..."
+    rm -rf "$TARGET_DIR"
+fi
+
+echo "Initializing marge_simpson/..."
+
+# Create directory structure
+mkdir -p "$TARGET_DIR/verify_logs"
+
+# Symlink shared resources
+SHARED_LINKS=(
+    "AGENTS.md"
+    "assets"
+    "experts"
+    "knowledge"
+    "model_pricing.json"
+    "prompt_examples"
+    "README.md"
+    "scripts"
+    "VERSION"
+    "workflows"
+)
+
+for item in "${SHARED_LINKS[@]}"; do
+    if [[ -e "$MARGE_HOME/shared/$item" ]]; then
+        ln -s "$MARGE_HOME/shared/$item" "$TARGET_DIR/$item"
+    fi
+done
+
+# Copy per-project templates
+TEMPLATE_FILES=(
+    "assessment.md"
+    "instructions_log.md"
+    "tasklist.md"
+    "verify.config.json"
+)
+
+for item in "${TEMPLATE_FILES[@]}"; do
+    if [[ -e "$MARGE_HOME/templates/$item" ]]; then
+        cp "$MARGE_HOME/templates/$item" "$TARGET_DIR/"
+    fi
+done
+
+# Update .gitignore
+if [[ "$UPDATE_GITIGNORE" -eq 1 ]]; then
+    if [[ -f ".gitignore" ]]; then
+        if ! grep -q "^marge_simpson/$" .gitignore 2>/dev/null; then
+            echo "" >> .gitignore
+            echo "# Marge workflow folder (local tooling)" >> .gitignore
+            echo "marge_simpson/" >> .gitignore
+            echo "Added marge_simpson/ to .gitignore"
+        fi
+    else
+        echo "# Marge workflow folder (local tooling)" > .gitignore
+        echo "marge_simpson/" >> .gitignore
+        echo "Created .gitignore with marge_simpson/"
+    fi
+fi
+
+echo ""
+echo "✓ marge_simpson/ initialized"
+echo ""
+echo "Structure:"
+echo "  marge_simpson/"
+echo "  ├── AGENTS.md           → $MARGE_HOME/shared/ (symlink)"
+echo "  ├── experts/            → $MARGE_HOME/shared/ (symlink)"
+echo "  ├── workflows/          → $MARGE_HOME/shared/ (symlink)"
+echo "  ├── scripts/            → $MARGE_HOME/shared/ (symlink)"
+echo "  ├── knowledge/          → $MARGE_HOME/shared/ (symlink)"
+echo "  ├── assessment.md       (local - per-project)"
+echo "  ├── tasklist.md         (local - per-project)"
+echo "  ├── verify.config.json  (local - per-project)"
+echo "  ├── instructions_log.md (local - per-project)"
+echo "  └── verify_logs/        (local - per-project)"
+echo ""
+echo "Edit verify.config.json to configure your project's test commands."
+echo ""
+echo "Ready to use marge! Start with:"
+echo "  - Read marge_simpson/AGENTS.md for workflow rules"
+echo "  - Add tasks to marge_simpson/tasklist.md"
+echo "  - Run verification: ./marge_simpson/scripts/verify.sh fast"

--- a/marge-init.ps1
+++ b/marge-init.ps1
@@ -1,0 +1,166 @@
+<#
+.SYNOPSIS
+    Initialize marge_simpson/ in the current project directory.
+
+.DESCRIPTION
+    Creates a hybrid setup with:
+    - Symlinks to global shared resources (AGENTS.md, experts, workflows, etc.)
+    - Local per-project files (assessment.md, tasklist.md, verify_logs/)
+
+.PARAMETER Force
+    Overwrite existing marge_simpson/ folder.
+
+.PARAMETER NoGitignore
+    Don't add marge_simpson/ to .gitignore.
+
+.PARAMETER MargeHome
+    Path to global marge installation. Default: $env:USERPROFILE\.marge
+    Can also be set via MARGE_HOME environment variable.
+
+.EXAMPLE
+    marge-init
+    marge-init -Force
+    marge-init -MargeHome "D:\tools\marge"
+#>
+
+param(
+    [switch]$Force,
+    [switch]$NoGitignore,
+    [string]$MargeHome = $null
+)
+
+$ErrorActionPreference = "Stop"
+
+# Determine MARGE_HOME
+if (-not $MargeHome) {
+    $MargeHome = if ($env:MARGE_HOME) { $env:MARGE_HOME } else { "$env:USERPROFILE\.marge" }
+}
+
+$TargetDir = ".\marge_simpson"
+
+# Validate global installation
+if (-not (Test-Path "$MargeHome\shared")) {
+    Write-Error @"
+Global marge installation not found at $MargeHome
+
+Install marge globally first:
+  .\install-global.ps1
+
+Or set MARGE_HOME to your installation directory:
+  `$env:MARGE_HOME = "D:\path\to\marge"
+"@
+    exit 1
+}
+
+if (Test-Path $TargetDir) {
+    if (-not $Force) {
+        Write-Error "$TargetDir already exists. Use -Force to overwrite, or remove it manually."
+        exit 1
+    }
+    Write-Host "Removing existing $TargetDir..."
+    Remove-Item -Recurse -Force $TargetDir
+}
+
+Write-Host "Initializing marge_simpson/..."
+
+# Create directory structure
+New-Item -ItemType Directory -Force -Path "$TargetDir\verify_logs" | Out-Null
+
+# Create symlinks to shared resources
+# Note: Creating symlinks on Windows may require admin privileges or Developer Mode
+$SharedLinks = @(
+    "AGENTS.md",
+    "assets",
+    "experts",
+    "knowledge",
+    "model_pricing.json",
+    "prompt_examples",
+    "README.md",
+    "scripts",
+    "VERSION",
+    "workflows"
+)
+
+$SymlinkFailed = $false
+foreach ($item in $SharedLinks) {
+    $srcPath = "$MargeHome\shared\$item"
+    $dstPath = "$TargetDir\$item"
+
+    if (Test-Path $srcPath) {
+        try {
+            if (Test-Path $srcPath -PathType Container) {
+                New-Item -ItemType SymbolicLink -Path $dstPath -Target $srcPath -ErrorAction Stop | Out-Null
+            } else {
+                New-Item -ItemType SymbolicLink -Path $dstPath -Target $srcPath -ErrorAction Stop | Out-Null
+            }
+        } catch {
+            # Fall back to copying if symlinks fail (non-admin Windows)
+            if (-not $SymlinkFailed) {
+                Write-Warning "Symlinks require admin privileges or Developer Mode. Falling back to copies."
+                $SymlinkFailed = $true
+            }
+            Copy-Item -Recurse -Force $srcPath $dstPath
+        }
+    }
+}
+
+# Copy per-project templates
+$TemplateFiles = @(
+    "assessment.md",
+    "instructions_log.md",
+    "tasklist.md",
+    "verify.config.json"
+)
+
+foreach ($item in $TemplateFiles) {
+    $srcPath = "$MargeHome\templates\$item"
+    if (Test-Path $srcPath) {
+        Copy-Item -Force $srcPath "$TargetDir\"
+    }
+}
+
+# Update .gitignore
+if (-not $NoGitignore) {
+    $gitignorePath = ".\.gitignore"
+    $margeEntry = "marge_simpson/"
+
+    if (Test-Path $gitignorePath) {
+        $content = Get-Content $gitignorePath -Raw -ErrorAction SilentlyContinue
+        if ($content -notmatch "(?m)^marge_simpson/`$") {
+            Add-Content $gitignorePath "`n# Marge workflow folder (local tooling)`nmarge_simpson/"
+            Write-Host "Added marge_simpson/ to .gitignore"
+        }
+    } else {
+        Set-Content $gitignorePath "# Marge workflow folder (local tooling)`nmarge_simpson/"
+        Write-Host "Created .gitignore with marge_simpson/"
+    }
+}
+
+Write-Host ""
+Write-Host "marge_simpson/ initialized" -ForegroundColor Green
+Write-Host ""
+
+if ($SymlinkFailed) {
+    Write-Host "Structure (copies - symlinks unavailable):"
+} else {
+    Write-Host "Structure:"
+}
+
+Write-Host "  marge_simpson\"
+Write-Host "  ├── AGENTS.md           → $MargeHome\shared\ $(if($SymlinkFailed){'(copy)'}else{'(symlink)'})"
+Write-Host "  ├── experts\            → $MargeHome\shared\ $(if($SymlinkFailed){'(copy)'}else{'(symlink)'})"
+Write-Host "  ├── workflows\          → $MargeHome\shared\ $(if($SymlinkFailed){'(copy)'}else{'(symlink)'})"
+Write-Host "  ├── scripts\            → $MargeHome\shared\ $(if($SymlinkFailed){'(copy)'}else{'(symlink)'})"
+Write-Host "  ├── knowledge\          → $MargeHome\shared\ $(if($SymlinkFailed){'(copy)'}else{'(symlink)'})"
+Write-Host "  ├── assessment.md       (local - per-project)"
+Write-Host "  ├── tasklist.md         (local - per-project)"
+Write-Host "  ├── verify.config.json  (local - per-project)"
+Write-Host "  ├── instructions_log.md (local - per-project)"
+Write-Host "  └── verify_logs\        (local - per-project)"
+Write-Host ""
+Write-Host "Edit verify.config.json to configure your project's test commands."
+Write-Host ""
+Write-Host "Ready to use marge! Start with:"
+Write-Host "  - Read marge_simpson\AGENTS.md for workflow rules"
+Write-Host "  - Add tasks to marge_simpson\tasklist.md"
+Write-Host "  - Run verification: .\marge_simpson\scripts\verify.ps1 fast"


### PR DESCRIPTION
Closes #1

## Summary

Adds a hybrid installation option for users working across multiple projects who want:
- **Clean repos** — `marge_simpson/` is gitignored, not committed
- **Shared resources** — experts, workflows, and knowledge shared globally  
- **Per-project tracking** — MS-IDs and logs isolated per project

## Changes

**New files:**
- `install-global.sh` / `install-global.ps1` — Install marge globally to `~/.marge`
- `marge-init` / `marge-init.ps1` — Initialize `marge_simpson/` in any project with symlinks

**Updated:**
- `README.md` — Added "Option B: Global Install" documentation

## How It Works

**Global structure (`~/.marge/`):**
```
~/.marge/
├── shared/           # Symlinked to all projects
│   ├── AGENTS.md
│   ├── experts/      # Custom experts available everywhere
│   ├── workflows/
│   ├── scripts/
│   └── knowledge/
├── templates/        # Copied per-project
│   ├── assessment.md
│   ├── tasklist.md
│   └── verify.config.json
└── marge-init        # Project initialization script
```

**Per-project (`marge_simpson/`):**
```
marge_simpson/
├── AGENTS.md           → ~/.marge/shared/ (symlink)
├── experts/            → ~/.marge/shared/ (symlink)
├── workflows/          → ~/.marge/shared/ (symlink)
├── scripts/            → ~/.marge/shared/ (symlink)
├── assessment.md       (local - per-project)
├── tasklist.md         (local - per-project)
├── verify.config.json  (local - project-specific test commands)
└── verify_logs/        (local)
```

## Usage

```bash
# One-time global install
./install-global.sh

# Initialize any project
cd my-project
marge-init
```

## Compatibility

- Existing drop-in installation unchanged
- All marge paths resolve correctly (full interoperability)
- Windows: Falls back to copies if symlinks unavailable (non-admin)
- Tested on Linux; PowerShell versions included for Windows

## Test Plan

- [x] `install-global.sh` creates correct structure
- [x] `marge-init` creates symlinks and copies templates
- [x] Symlinks resolve correctly
- [x] `.gitignore` updated automatically
- [x] `--force` flag works for reinstall
- [ ] Windows testing (PowerShell scripts included but not tested)